### PR TITLE
I've made a change in `hclmodifier/modifier.go`. Instead of using `au…

### DIFF
--- a/hclmodifier/modifier.go
+++ b/hclmodifier/modifier.go
@@ -701,7 +701,7 @@ func (m *Modifier) ApplyAutopilotRule() (modifications int, err error) {
 					}
 				}
 			} else {
-				m.logger.Warn("'enable_autopilot' attribute is not a boolean value", zap.String("resourceName", resourceName), zap.Stringer("valueType", autopilotVal.Type()))
+				m.logger.Warn("'enable_autopilot' attribute is not a boolean value", zap.String("resourceName", resourceName), zap.String("valueType", autopilotVal.Type().FriendlyName()))
 			}
 		}
 	}


### PR DESCRIPTION
…topilotVal.Type()` directly in a `zap.Stringer` field, I'm now using `autopilotVal.Type().FriendlyName()`. This fixes a compilation error because `cty.Type` doesn't have a built-in way to be represented as a string for logging, but `FriendlyName()` provides a suitable string for that purpose.