### PR TITLE
feat: Add new GKE cluster cleaning rules and suggest improvements

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,24 @@ var rootCmd = &cobra.Command{
 			logger.Info("ApplyAutopilotRule completed", zap.Int("modifications", autopilotModifications), zap.String("filePath", filePathVariable))
 		}
 
+		// Apply InitialNodeCount Rule
+		logger.Info("Applying InitialNodeCount Rule...")
+		initialNodeCountModifications, err := hclFile.ApplyInitialNodeCountRule()
+		if err != nil {
+			logger.Error("Error applying InitialNodeCount Rule", zap.Error(err), zap.String("filePath", filePathVariable))
+		} else {
+			logger.Info("InitialNodeCount Rule application completed", zap.Int("modifications", initialNodeCountModifications), zap.String("filePath", filePathVariable))
+		}
+
+		// Apply MasterCIDR Rule
+		logger.Info("Applying MasterCIDR Rule...")
+		masterCIDRModifications, err := hclFile.ApplyMasterCIDRRule()
+		if err != nil {
+			logger.Error("Error applying MasterCIDR Rule", zap.Error(err), zap.String("filePath", filePathVariable))
+		} else {
+			logger.Info("MasterCIDR Rule application completed", zap.Int("modifications", masterCIDRModifications), zap.String("filePath", filePathVariable))
+		}
+
 		// 4. Write the modified HCL content back to the file using the hclmodifier package.
 		err = hclFile.WriteToFile(filePathVariable)
 		if err != nil {


### PR DESCRIPTION
This commit introduces two new rules for cleaning Terraform HCL exports of 'google_container_cluster' resources:

1.  **InitialNodeCountRule:**
    *   Removes `initial_node_count` from `node_pool` blocks if `node_count` is also present.
    *   Removes `initial_node_count` if it's present and `node_count` is absent, to ensure cleaner imports.
    *   Includes logging for applied changes.

2.  **MasterCIDRRule:**
    *   Removes `private_cluster_config.private_endpoint_subnetwork` if the top-level `master_ipv4_cidr_block` is also set.
    *   This prioritizes `master_ipv4_cidr_block` for defining the master's CIDR.
    *   Includes logging for applied changes.

Both new rules are integrated into the CLI and have comprehensive unit tests covering various scenarios.

Additionally, this commit implicitly includes considerations for future refactoring and improvements that were analyzed as part of this change, such as:
*   Data-driven rule application in `cmd/root.go`.
*   Consistent error handling strategies.
*   Enhanced logging and test structure for maintainability.