### PR TITLE
feat: add rule to remove node_version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ var rootCmd = &cobra.Command{
 			hclmodifier.Rule3Definition,
 			hclmodifier.RuleRemoveLoggingService,
 			hclmodifier.RuleRemoveMonitoringService,
+			hclmodifier.RuleRemoveNodeVersion,
 			// Note: InitialNodeCountRule and AutopilotRule are handled separately below
 			// due to their complex logic not yet fully translated to the generic rule engine.
 		}

--- a/hclmodifier/modifier.go
+++ b/hclmodifier/modifier.go
@@ -629,6 +629,28 @@ var RuleRemoveMonitoringService = Rule{
 	},
 }
 
+// RuleRemoveNodeVersion defines a rule to remove node_version if min_master_version is also present.
+var RuleRemoveNodeVersion = Rule{
+	Name:               "Remove node_version if min_master_version exists",
+	TargetResourceType: "google_container_cluster",
+	Conditions: []RuleCondition{
+		{
+			Type: AttributeExists,
+			Path: []string{"node_version"},
+		},
+		{
+			Type: AttributeExists,
+			Path: []string{"min_master_version"},
+		},
+	},
+	Actions: []RuleAction{
+		{
+			Type: RemoveAttribute,
+			Path: []string{"node_version"},
+		},
+	},
+}
+
 // --- Rule Engine Structures and Processor Signature ---
 
 // ConditionType defines the type of condition to check.


### PR DESCRIPTION
This commit introduces a new rule to the HCL modifier.

Rule: Remove `node_version` from `google_container_cluster` resources if `min_master_version` is also present.

This addresses an issue where Terraform import generates both attributes, leading to a conflict on `terraform apply` because `node_version` and `min_master_version` must be equivalent on creation. Removing `node_version` resolves this conflict.

The following changes were made:
- Defined `RuleRemoveNodeVersion` in `hclmodifier/modifier.go`.
- Added `RuleRemoveNodeVersion` to the list of rules applied in `cmd/root.go`.
- Added comprehensive test cases in `hclmodifier/modifier_test.go` to cover various scenarios, including:
    - Both versions present (node_version removed).
    - Only node_version present (node_version kept).
    - Only min_master_version present (no change).
    - Neither version present (no change).
    - Rule applied to non-target resource types (no change).
    - Rule applied to complex GKE resource (node_version removed, others intact).