### PR TITLE
Refactor: Improve rule engine, comments, and code hygiene

### DIFF
--- a/hclmodifier/autopilot_rule.go
+++ b/hclmodifier/autopilot_rule.go
@@ -10,29 +10,6 @@ import (
 	"github.com/kotatut/cluster_import_cleaner/hclmodifier/types" // Import for type definitions
 )
 
-// AutopilotRuleDefinition is a placeholder for the AutopilotRule because its complex logic,
-// involving conditional checks and removal of various attributes and blocks,
-// is handled by the direct implementation in ApplyAutopilotRule.
-// This definition is not meant to be used by the generic ApplyRules engine.
-//
-// What it does (effectively via ApplyAutopilotRule): If `enable_autopilot` is true, it removes many attributes
-// and blocks that are incompatible or managed by Autopilot (e.g., `node_pool` blocks, `cluster_ipv4_cidr`,
-// certain `addons_config` sub-blocks, `cluster_autoscaling.enabled`, etc.). If `enable_autopilot` is explicitly
-// set to false or is not a boolean, it removes the `enable_autopilot` attribute itself to clean up potentially
-// invalid or confusing states from an import.
-//
-// Why it's necessary for GKE imports: When importing a standard GKE cluster and then trying to convert it to
-// Autopilot by setting `enable_autopilot = true`, or when importing an existing Autopilot cluster, many
-// attributes valid for standard clusters become invalid or are managed by Autopilot. Terraform might produce
-// errors if these attributes are left in the configuration. This rule (via its direct function) cleans these up.
-// If an imported cluster has `enable_autopilot = false` or an invalid value for it, removing the attribute
-// helps avoid potential errors if the user intends to manage it as a standard cluster or correct the attribute.
-var AutopilotRuleDefinition = types.Rule{ // Use types.Rule
-	Name:               "Autopilot Configuration Cleanup Rule (handled by ApplyAutopilotRule)",
-	TargetResourceType: "google_container_cluster",
-	// Conditions and Actions are omitted as this rule is not processed by the generic engine.
-}
-
 // ApplyAutopilotRule cleans a `google_container_cluster` resource configuration based on the `enable_autopilot` attribute.
 // If `enable_autopilot = true`, it removes attributes and blocks that are incompatible with Autopilot mode.
 // This includes node pools, certain network settings, and specific autoscaling/binary authorization fields.
@@ -86,38 +63,45 @@ func (m *Modifier) ApplyAutopilotRule() (modifications int, err error) {
 			}
 
 			isAutopilotTrue := false
-			removeEnableAutopilotAttr := false
+			removeEnableAutopilotNonBool := false
 
 			if autopilotVal.Type() == cty.Bool {
 				if autopilotVal.True() {
 					isAutopilotTrue = true
 					resLogger.Info("Autopilot enabled. Applying necessary modifications.")
 				} else {
-					// enable_autopilot = false
-					resLogger.Info("Autopilot explicitly disabled. Removing 'enable_autopilot' attribute itself.")
-					removeEnableAutopilotAttr = true
+					// enable_autopilot = false. This case is now handled by the generic RuleHandleAutopilotFalse.
+					// No action needed here for enable_autopilot = false itself.
+					resLogger.Debug("Autopilot explicitly disabled (enable_autopilot = false). Generic rule will handle removal.")
+					// We can 'continue' here because if it's false, no other logic in this function applies.
+					continue
 				}
 			} else {
 				// enable_autopilot is not a boolean (e.g., "not_a_boolean")
 				resLogger.Warn("'enable_autopilot' attribute is not a boolean value. Removing attribute.", zap.String("valueType", autopilotVal.Type().FriendlyName()))
-				removeEnableAutopilotAttr = true
+				removeEnableAutopilotNonBool = true
 			}
 
-			if removeEnableAutopilotAttr {
+			if removeEnableAutopilotNonBool {
+				// This part handles only the non-boolean case. The 'false' boolean case is handled by the new generic rule.
 				if _, existingAttrCheck, _ := m.GetAttributeValueByPath(block.Body(), []string{"enable_autopilot"}); existingAttrCheck != nil {
 					if errRemove := m.RemoveAttributeByPath(block.Body(), []string{"enable_autopilot"}); errRemove != nil {
-						resLogger.Error("Error removing 'enable_autopilot' attribute.", zap.Error(errRemove))
+						resLogger.Error("Error removing non-boolean 'enable_autopilot' attribute.", zap.Error(errRemove))
 						if firstError == nil {
 							firstError = errRemove
 						}
 					} else {
 						modificationCount++
-						resLogger.Info("Successfully removed 'enable_autopilot' (false) attribute.")
+						resLogger.Info("Successfully removed non-boolean 'enable_autopilot' attribute.")
 					}
 				}
+				// After attempting removal of non-boolean, no further Autopilot-specific logic (like removing node_pools) should apply.
 				continue
 			}
 
+			// Only proceed with Autopilot-specific removals if isAutopilotTrue is actually true.
+			// The case for enable_autopilot = false is handled by RuleHandleAutopilotFalse.
+			// The case for enable_autopilot = non-boolean has its attribute removed and then we continue.
 			if isAutopilotTrue {
 				// Remove defined top-level attributes IF THEY EXIST
 				for _, attrName := range attributesToRemoveWhenTrue {

--- a/hclmodifier/initial_node_count_rule.go
+++ b/hclmodifier/initial_node_count_rule.go
@@ -8,82 +8,32 @@ import (
 	"github.com/kotatut/cluster_import_cleaner/hclmodifier/types" // Import for type definitions
 )
 
-// InitialNodeCountRuleDefinition is a placeholder for the InitialNodeCountRule because its logic,
-// which involves iterating over `node_pool` sub-blocks and conditionally removing attributes,
-// is handled by the direct implementation in ApplyInitialNodeCountRule.
-// This definition is not meant to be used by the generic ApplyRules engine.
+// InitialNodeCountRuleDefinition defines a rule that removes the `initial_node_count` attribute
+// from all `node_pool` sub-blocks within a `google_container_cluster` resource.
+// This rule is processed by the generic ApplyRules engine using RuleExecutionForEachNestedBlock.
 //
-// What it does (effectively via ApplyInitialNodeCountRule): For each `node_pool` within a `google_container_cluster`,
-// it removes the `initial_node_count` attribute if it exists. It doesn't matter if `node_count` is present or not.
+// What it does: For each `node_pool` block within a `google_container_cluster` resource,
+// if the `initial_node_count` attribute exists within that `node_pool`, it will be removed.
 //
 // Why it's necessary for GKE imports: After importing a GKE cluster, `node_pool` blocks might contain
 // `initial_node_count`. While this attribute is used for creation, for existing node pools (especially those
 // managed by autoscaling or with a `node_count` attribute), `initial_node_count` can be problematic.
-// It can cause diffs if the current node count (managed by `node_count` or autoscaler) doesn't match,
-// or it might attempt to resize the node pool on apply if `node_count` is not set.
-// Removing `initial_node_count` defers to `node_count` or autoscaling for managing the number of nodes,
-// which is generally the desired state for imported and ongoing management.
-var InitialNodeCountRuleDefinition = types.Rule{ // Use types.Rule
-	Name:               "Initial Node Count Rule: Remove initial_node_count from node_pools (handled by ApplyInitialNodeCountRule)",
-	TargetResourceType: "google_container_cluster",
-	// Conditions and Actions are omitted as this rule is not processed by the generic engine.
-}
-
-// ApplyInitialNodeCountRule removes the `initial_node_count` attribute from all `node_pool` blocks
-// within a `google_container_cluster` resource. This is to prevent conflicts or unintended resize
-// operations after a cluster import, as `node_count` or autoscaling should manage the node count
-// for existing node pools.
-//
-// This function is called directly and does not use the generic Rule engine due to its specific
-// iteration and logic for `node_pool` sub-blocks.
-func (m *Modifier) ApplyInitialNodeCountRule() (modifications int, err error) {
-	modificationCount := 0
-	var firstError error
-	m.Logger.Info("Starting ApplyInitialNodeCountRule (using path-based helpers).")
-
-	if m.File() == nil || m.File().Body() == nil {
-		m.Logger.Error("ApplyInitialNodeCountRule: Modifier's file or file body is nil.")
-		return 0, fmt.Errorf("modifier's file or file body cannot be nil")
-	}
-
-	for _, block := range m.File().Body().Blocks() {
-		if block.Type() == "resource" && len(block.Labels()) == 2 && block.Labels()[0] == "google_container_cluster" {
-			resourceName := block.Labels()[1]
-			clusterLogger := m.Logger.With(zap.String("resourceName", resourceName), zap.String("rule", "ApplyInitialNodeCountRule"))
-			clusterLogger.Debug("Checking 'google_container_cluster' resource.")
-
-			for _, nodePoolBlock := range block.Body().Blocks() {
-				if nodePoolBlock.Type() == "node_pool" {
-					nodePoolLogger := clusterLogger.With(zap.String("nodePoolType", nodePoolBlock.Type()))
-					nodePoolLogger.Debug("Checking 'node_pool' block.")
-
-					// Check if 'initial_node_count' exists in this node_pool block.
-					_, _, errAttr := m.GetAttributeValueByPath(nodePoolBlock.Body(), []string{"initial_node_count"})
-
-					if errAttr == nil { // Attribute exists
-						nodePoolLogger.Info("Found 'initial_node_count' in node_pool. Removing it.")
-						errRemove := m.RemoveAttributeByPath(nodePoolBlock.Body(), []string{"initial_node_count"})
-						if errRemove != nil {
-							nodePoolLogger.Error("Error removing 'initial_node_count' from node_pool.", zap.Error(errRemove))
-							if firstError == nil {
-								firstError = fmt.Errorf("failed to remove 'initial_node_count' from node_pool in resource '%s': %w", resourceName, errRemove)
-							}
-						} else {
-							modificationCount++
-							nodePoolLogger.Info("Successfully removed 'initial_node_count' from node_pool.")
-						}
-					} else {
-						// GetAttributeValueByPath already logs debug messages for attribute not found.
-						nodePoolLogger.Debug("Attribute 'initial_node_count' not found in this node_pool.", zap.Error(errAttr))
-					}
-				}
-			}
-		}
-	}
-
-	m.Logger.Info("ApplyInitialNodeCountRule finished.", zap.Int("modifications", modificationCount))
-	if firstError != nil {
-		m.Logger.Error("ApplyInitialNodeCountRule encountered errors during processing.", zap.Error(firstError))
-	}
-	return modificationCount, firstError
+// Removing `initial_node_count` defers to `node_count` or autoscaling for managing the number of nodes.
+var InitialNodeCountRuleDefinition = types.Rule{
+	Name:                  "Initial Node Count Rule: Remove initial_node_count from node_pools",
+	TargetResourceType:    "google_container_cluster",
+	ExecutionType:         types.RuleExecutionForEachNestedBlock,
+	NestedBlockTargetType: "node_pool",
+	Conditions: []types.RuleCondition{
+		{
+			Type: types.AttributeExists,
+			Path: []string{"initial_node_count"}, // Path relative to the node_pool block
+		},
+	},
+	Actions: []types.RuleAction{
+		{
+			Type: types.RemoveAttribute,
+			Path: []string{"initial_node_count"}, // Path relative to the node_pool block
+		},
+	},
 }

--- a/hclmodifier/rules/autopilot_rules.go
+++ b/hclmodifier/rules/autopilot_rules.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	"github.com/kotatut/cluster_import_cleaner/hclmodifier/types"
+)
+
+// RuleHandleAutopilotFalse defines a rule to clean up 'enable_autopilot'
+// when it is explicitly set to false.
+//
+// What it does: It checks if a 'google_container_cluster' resource has the
+// 'enable_autopilot' attribute set to 'false'. If so, it removes the attribute.
+//
+// Why it's necessary for GKE imports: If 'enable_autopilot' is 'false', it's often
+// redundant as it's the default behavior for standard clusters if the attribute is
+// omitted entirely. Removing it simplifies the configuration.
+var RuleHandleAutopilotFalse = types.Rule{
+	Name:               "Autopilot Cleanup: Remove 'enable_autopilot' if explicitly set to false",
+	TargetResourceType: "google_container_cluster",
+	ExecutionType:      types.RuleExecutionStandard, // Or can be omitted for default
+	Conditions: []types.RuleCondition{
+		{
+			Type: types.AttributeExists,
+			Path: []string{"enable_autopilot"},
+		},
+		{
+			Type:          types.AttributeValueEquals,
+			Path:          []string{"enable_autopilot"},
+			ExpectedValue: "false",
+		},
+	},
+	Actions: []types.RuleAction{
+		{
+			Type: types.RemoveAttribute,
+			Path: []string{"enable_autopilot"},
+		},
+	},
+}

--- a/hclmodifier/rules/cluster_ipv4_cidr_rule.go
+++ b/hclmodifier/rules/cluster_ipv4_cidr_rule.go
@@ -39,9 +39,5 @@ var ClusterIPV4CIDRRuleDefinition = types.Rule{
 			Type: types.RemoveAttribute,
 			Path: []string{"cluster_ipv4_cidr"},
 		},
-		{
-			Type: types.RemoveAttribute,
-			Path: []string{"ip_allocation_policy", "cluster_ipv4_cidr_block"},
-		},
 	},
 }

--- a/hclmodifier/types/types.go
+++ b/hclmodifier/types/types.go
@@ -24,6 +24,16 @@ const (
 	SetAttributeValue ActionType = "SetAttributeValue" // SetAttributeValue sets a specific attribute at the given path to a certain value.
 )
 
+// RuleExecutionType defines how a rule should be executed.
+type RuleExecutionType string
+
+const (
+	// RuleExecutionStandard indicates that the rule is applied to the resource block itself.
+	RuleExecutionStandard RuleExecutionType = "Standard"
+	// RuleExecutionForEachNestedBlock indicates that the rule is applied to each nested block of a specific type within the resource block.
+	RuleExecutionForEachNestedBlock RuleExecutionType = "ForEachNestedBlock"
+)
+
 // RuleCondition defines a specific condition that must be met for a Rule's actions to be triggered.
 // It specifies the type of check, the path to the HCL element, and an optional expected value.
 type RuleCondition struct {
@@ -70,4 +80,12 @@ type Rule struct {
 	TargetResourceLabels []string
 	Conditions           []RuleCondition // Conditions is a list of conditions that must ALL be true (AND logic) for the actions to be performed.
 	Actions              []RuleAction    // Actions is a list of actions to be performed if all conditions are met.
+	// ExecutionType specifies how the rule is executed. Defaults to RuleExecutionStandard.
+	ExecutionType RuleExecutionType
+	// NestedBlockTargetType is relevant when ExecutionType is RuleExecutionForEachNestedBlock.
+	// It specifies the type of nested block to target (e.g., "node_pool").
+	NestedBlockTargetType string
+	// NestedBlockTargetLabels provide optional label criteria for the nested block.
+	// If empty, the rule applies to all nested blocks of NestedBlockTargetType.
+	NestedBlockTargetLabels []string
 }


### PR DESCRIPTION
This commit introduces several improvements to the HCL modification tool:

- Clarified `ClusterIPV4CIDRRuleDefinition`: I've corrected the rule to only remove the top-level `cluster_ipv4_cidr` when `ip_allocation_policy.cluster_ipv4_cidr_block` exists, aligning with its intended behavior of favoring the latter.

- Enhanced Generic Rule Engine for Nested Blocks:
    - I've extended `types.Rule` with `ExecutionType` and `NestedBlockTargetType` to allow rules to operate on all nested blocks of a specific type within a resource (e.g., all `node_pool` blocks in a `google_container_cluster`).
    - I've updated `modifier.ApplyRules` to handle this new `RuleExecutionForEachNestedBlock` execution type.
    - I've refactored `InitialNodeCountRule`: It now uses the generic rule engine with the new nested block execution type, removing the need for the custom `ApplyInitialNodeCountRule` function.

- Refactored `AutopilotRule`:
    - I've ensured the case where `enable_autopilot` is explicitly `false` is now handled by a new generic rule (`RuleHandleAutopilotFalse`).
    - I've simplified the custom `ApplyAutopilotRule` function, focusing on the `enable_autopilot = true` scenario and the case where `enable_autopilot` is not a boolean.

- Improved Code Clarity and Comments:
    - I've updated comments in `modifier.go` (especially `ApplyRules`) and rule definitions to reflect the new logic and improve understanding.
    - I've cleaned up logger handling in `main.go` by removing an unused variable and clarifying comments.

- Removed Dead Code:
    - I've deleted the unused `AutopilotRuleDefinition` variable from `hclmodifier/autopilot_rule.go`.
    - I've deleted the unused exported function `RemoveAttributes` from `hclmodifier/modifier.go`.

These changes centralize more logic into the generic rule engine, improve code maintainability, and enhance overall clarity.