### PR TITLE
Refactor: Enhance GKE Autopilot cleanup rules

### DIFF
--- a/hclmodifier/modifier_test.go
+++ b/hclmodifier/modifier_test.go
@@ -2041,6 +2041,19 @@ func TestApplyAutopilotRule(t *testing.T) {
   default_max_pods_per_node     = 110
   enable_intranode_visibility   = true
 
+  node_config {
+    machine_type = "e2-standard-4"
+    disk_size_gb = 100
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+  }
+
   addons_config {
     network_policy_config {
       disabled = false
@@ -2080,7 +2093,7 @@ func TestApplyAutopilotRule(t *testing.T) {
     enabled = true
   }
 }`,
-			expectedModifications:     13,
+			expectedModifications:     14,
 			clusterName:               "autopilot_cluster",
 			expectEnableAutopilotAttr: boolPtr(true),
 			expectedRootAttrsRemoved: []string{
@@ -2093,6 +2106,8 @@ func TestApplyAutopilotRule(t *testing.T) {
 			expectedTopLevelNestedBlocksRemoved: []string{
 				"network_policy",
 				"node_pool",
+				"cluster_autoscaling",
+				"node_config",
 			},
 			addonsConfig: &addonsConfigChecks{
 				expectBlockExists:                true,
@@ -2102,10 +2117,7 @@ func TestApplyAutopilotRule(t *testing.T) {
 				expectHttpLoadBalancingUnchanged: true,
 			},
 			clusterAutoscaling: &clusterAutoscalingChecks{
-				expectBlockExists:           true,
-				expectEnabledRemoved:        true,
-				expectResourceLimitsRemoved: true,
-				expectProfileUnchanged:      stringPtr("OPTIMIZE_UTILIZATION"),
+				expectBlockExists:           false, // This signifies the entire block should be removed
 			},
 			binaryAuthorization: &binaryAuthorizationChecks{
 				expectBlockExists:    true,

--- a/hclmodifier/rules/autopilot_rules.go
+++ b/hclmodifier/rules/autopilot_rules.go
@@ -65,9 +65,11 @@ var AutopilotRules = []types.Rule{
 			{Type: types.RemoveBlock, Path: []string{"addons_config", "dns_cache_config"}},
 			{Type: types.RemoveBlock, Path: []string{"addons_config", "stateful_ha_config"}},
 
-			// Remove attributes and sub-blocks from cluster_autoscaling
-			{Type: types.RemoveAttribute, Path: []string{"cluster_autoscaling", "enabled"}},
-			{Type: types.RemoveAllNestedBlocksMatchingPath, Path: []string{"cluster_autoscaling", "resource_limits"}},
+			// Remove cluster_autoscaling block
+			{Type: types.RemoveBlock, Path: []string{"cluster_autoscaling"}},
+
+			// Remove node_config block
+			{Type: types.RemoveBlock, Path: []string{"node_config"}},
 
 			// Remove attributes from binary_authorization
 			{Type: types.RemoveAttribute, Path: []string{"binary_authorization", "enabled"}},


### PR DESCRIPTION
This change enhances the cleanup rules for GKE clusters imported into Terraform, specifically when Autopilot is enabled.

The following modifications have been made:

1.  **Autopilot Rule Enhancement (`hclmodifier/rules/autopilot_rules.go`):**
    *   The rule for `enable_autopilot = true` now removes the *entire* `cluster_autoscaling` block, instead of just specific attributes within it. This aligns better with Autopilot managing these settings.
    *   The same rule now also removes the *entire* `node_config` block, as node configurations are managed by Autopilot.

2.  **Value Parsing Review (`hclmodifier/modifier.go`):**
    *   I reviewed the existing value parsing logic within `checkCondition` (for `AttributeValueEquals`) and `performAction` (for `SetAttributeValue`). The current implementation for parsing string representations of booleans, numbers, and strings into `cty.Value` was deemed adequate for the existing and anticipated rule complexity. No changes were made to this logic.

3.  **Test Updates (`hclmodifier/modifier_test.go`):**
    *   The `TestApplyAutopilotRule`, specifically the test case `"enable_autopilot is true, all conflicting fields present"`, has been updated:
        *   Input HCL now includes a `node_config` block to test its removal.
        *   Assertions now verify the complete removal of both `cluster_autoscaling` and `node_config` blocks.
        *   The `expectedModifications` count was adjusted to 14 to reflect these changes accurately.

These changes ensure a cleaner and more accurate Terraform configuration for imported GKE Autopilot clusters by removing fields that are managed by Autopilot or are otherwise redundant.